### PR TITLE
Update PHP requirement to allow versions >=8.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": ">=8.0.0 <8.4.0",
+        "php": ">=8.0.0",
         "igorw/get-in": "^1.0",
         "laravie/codex-common": "^2.0"
     },


### PR DESCRIPTION
Adjust the PHP version requirement to support all versions starting from 8.0.0 without an upper limit.